### PR TITLE
Fixed regular expression in i18n_nif to handle dots in the path to the compiled libraries

### DIFF
--- a/src/i18n_nif.erl
+++ b/src/i18n_nif.erl
@@ -88,7 +88,7 @@
 get_timestamp_from_filename(Name) ->
     try
         List = re:replace(Name,
-                    "[^.]*\.([0-9]+)\.(dll|so)", "\\1", 
+                    ".*i18n_nif\.([0-9]+)\.(dll|so)", "\\1", 
                     [{return,list}]),
         case string:to_integer(List) of
         {Int, _Res} when is_integer(Int) ->


### PR DESCRIPTION
Modify regular expression for extracting the timestamp from the compiled NIF libraries so that dots in file paths will not prevent the timestamp from being correctly parsed.
